### PR TITLE
Enable dependabot on Go services

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you will need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    registries:
+      - github-octocat
+
+registries:
+  github-octocat:
+    type: git
+    url: https://go.lunarway.com
+    username: x-access-token
+    password: ${{ secrets.DEPENDABOT }}


### PR DESCRIPTION
This PR adds a dependabot.yaml file to enable automatic upgrades of dependencies in the service. This will let dependabot run daily to find updates for dependencies.
This is done to help you (and Lunar) make sure that also older services are updated regularly,
just like our newer services where Dependabot is enabled automatically as a part of the service template.
Keeping the dependencies in services up to date helps keeping the risk of a vulnerability being exploited low.

Be aware that dependabot only supports updating dependencies with semantic versions, see more on that here: https://backstage.lunar.tech/docs/default/Component/development-platform-docs/platform/automatic-dependency-updates/?env=prod

You are welcome to change the frequency to weekly if needed. The daily frequency is choosen in this PR is aligned with our current service templates.

If you find repositories and services that are no longer used follow the [Delete service guide](https://backstage.lunar.tech/docs/default/component/tech-guides/delete-service/) for details on how to remove it.
Ensuring that old, replicated and no longer used services are removed from Snyk helps Lunar in understanding the current risk level of services and their dependencies.

[_Created by Sourcegraph batch change `tsj/enable-dependabot-go-services`._](https://sourcegraph.lunar.tech/users/tsj/batch-changes/enable-dependabot-go-services)